### PR TITLE
add api host to embed builder

### DIFF
--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -175,6 +175,18 @@ export class EmbedBuilder<T> {
     this._url = url
     return this
   }
+  
+  /**
+   * specify api host
+   *
+   * @param apiHost
+   */
+
+  withApiHost(apiHost: string) {
+    this._hostSettings.apiHost = apiHost;
+    return this;
+  }
+
 
   /**
    * The element to append the embedded content to.


### PR DESCRIPTION
Currently, if you don't call 

```javascript
LookerEmbedSDK.init("host.looker.com", "/auth");
```

prior to 

```javascript
LookerEmbedSDK.createDashboardWithUrl(lookerEmbedUrl)
```

[this check will](https://github.com/looker-open-source/chatty/blob/master/src/host.ts#L199) evaluate to `false`. This PR allows the user to just directly start chaining events off of `LookerEmbedSDK.createDashboardWithUrl` without having to init.
