### PR TITLE
Drt/configure demo host port

### DIFF
--- a/config.js
+++ b/config.js
@@ -2,5 +2,7 @@ require('dotenv').config();
 
 module.exports = {
   host: process.env.LOOKER_EMBED_HOST || 'self-signed.looker.com:9999',
-  secret: process.env.LOOKER_EMBED_SECRET || 'ranger2'
+  secret: process.env.LOOKER_EMBED_SECRET,
+  demo_host: process.env.LOOKER_DEMO_HOST,
+  demo_port: process.env.LOOKER_DEMO_PORT,
 }

--- a/config.js
+++ b/config.js
@@ -3,6 +3,6 @@ require('dotenv').config();
 module.exports = {
   host: process.env.LOOKER_EMBED_HOST || 'self-signed.looker.com:9999',
   secret: process.env.LOOKER_EMBED_SECRET,
-  demo_host: process.env.LOOKER_DEMO_HOST,
-  demo_port: process.env.LOOKER_DEMO_PORT,
+  demo_host: process.env.LOOKER_DEMO_HOST || 'localhost',
+  demo_port: process.env.LOOKER_DEMO_PORT || 8080,
 }

--- a/webpack-devserver.config.js
+++ b/webpack-devserver.config.js
@@ -1,5 +1,6 @@
 var path = require('path')
 var config = require ('./config')
+
 var user = require('./demo/demo_user.json')
 var { createSignedUrl } = require('./server_utils/auth_utils')
 
@@ -36,6 +37,8 @@ var webpackConfig = {
     contentBase: [
       path.join(__dirname, "demo")
     ],
+    host: config.demo_host,
+    port: config.demo_port,
     watchContentBase: true,
     before: (app) => {
       app.get('/auth', function(req, res) {


### PR DESCRIPTION
Added env.LOOKER_DEMO_HOST and env.LOOKER_DEMO_PORT to config.js
use config.demo_host and config.demo_port in webpack dev server config options.

Fixes #18 