### PR TITLE
Allow a URL for apiHost parameter.

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -25,6 +25,8 @@
 import { EmbedBuilder } from './embed_builder'
 import { Chatty, ChattyHost, ChattyHostBuilder } from '@looker/chatty'
 
+const IS_URL = /^https?:\/\//
+
 /**
  * Wrapper for Looker embedded content. Provides a mechanism for creating the embedded content element,
  * and for establishing two-way communication between the parent window and the embedded content.
@@ -58,6 +60,11 @@ export class EmbedClient<T> {
     return !!this._connection
   }
 
+  get targetOrigin () {
+    const apiHost = this._builder.apiHost
+    return IS_URL.test(apiHost) ? apiHost : `https://${apiHost}`
+  }
+
   private async createIframe (url: string) {
     this._hostBuilder = Chatty.createHost(url)
     for (const eventType in this._builder.handlers) {
@@ -71,7 +78,7 @@ export class EmbedClient<T> {
     this._host = this._hostBuilder
       // tslint:disable-next-line:deprecation
       .frameBorder(this._builder.frameBorder)
-      .withTargetOrigin(`https://${this._builder.apiHost}`)
+      .withTargetOrigin(this.targetOrigin)
       .appendTo(this._builder.el)
       .build()
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -33,6 +33,13 @@ export { LookerEmbedLook } from './look_client'
 
 export class LookerEmbedSDK {
 
+  /**
+   * Initialize the Embed SDK.
+   *
+   * @param apiHost The address or base URL of the Looker host (example.looker.com:9999, https://example.looker.com:9999)
+   * @param authUrl A server endpoint that will sign SSO embed URLs
+   */
+
   static init (apiHost: string, authUrl?: string) {
     this.apiHost = apiHost
     this.authUrl = authUrl

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -25,25 +25,60 @@
 import { LookerEmbedSDK, LookerEmbedDashboard } from '../src/index'
 import { ChattyHost } from '@looker/chatty'
 import mock from 'xhr-mock'
-import { EmbedClient } from '../src/embed'
+import { EmbedBuilder } from '../src/embed_builder'
 
 const testUrl = '/base/tests/test.html'
 
 describe('LookerEmbed', () => {
-  let builder
-  let el
+  let builder: EmbedBuilder<any>
+  let el: HTMLDivElement
   let client: any
 
   beforeEach(() => {
-    LookerEmbedSDK.init('host.looker.com:9999', '/auth')
     el = document.createElement('div')
     el.id = 'the-element'
+    document.body.append(el)
+  })
+
+  afterEach(() => {
+    document.body.removeChild(el)
+  })
+
+  describe('targetOrigin', () => {
+    it('accepts a host:port for apiHost', () => {
+      LookerEmbedSDK.init('host.looker.com:9999')
+
+      builder = LookerEmbedSDK.createDashboardWithId(11)
+      client = builder.build()
+
+      expect(client.targetOrigin).toEqual('https://host.looker.com:9999')
+    })
+
+    it('accepts https://host:port for apiHost', () => {
+      LookerEmbedSDK.init('https://host.looker.com:9999')
+
+      builder = LookerEmbedSDK.createDashboardWithId(11)
+      client = builder.build()
+
+      expect(client.targetOrigin).toEqual('https://host.looker.com:9999')
+    })
+
+    it('accepts http://host:port for apiHost', () => {
+      LookerEmbedSDK.init('http://host.looker.com:9999')
+
+      builder = LookerEmbedSDK.createDashboardWithId(11)
+      client = builder.build()
+
+      expect(client.targetOrigin).toEqual('http://host.looker.com:9999')
+    })
   })
 
   describe('with ID', () => {
     let fakeDashboardClient: any
 
     beforeEach(() => {
+      LookerEmbedSDK.init('host.looker.com:9999', '/auth')
+
       mock.setup()
       mock.get(/\/auth\?src=/, (req, res) => {
         expect(req.header('Cache-Control')).toEqual('no-cache')
@@ -104,6 +139,8 @@ describe('LookerEmbed', () => {
     let fakeDashboardClient: any
 
     beforeEach(() => {
+      LookerEmbedSDK.init('host.looker.com:9999', '/auth')
+
       fakeDashboardClient = {}
       builder = LookerEmbedSDK.createDashboardWithUrl(testUrl)
       client = builder.build()
@@ -140,13 +177,10 @@ describe('LookerEmbed', () => {
 
   describe('creating an iframe', () => {
     let fakeDashboardClient
-    let el: HTMLDivElement
     let iframe: HTMLIFrameElement
 
     beforeEach(() => {
-      el = document.createElement('div')
-      el.id = 'the-element'
-      document.body.append(el)
+      LookerEmbedSDK.init('host.looker.com:9999', '/auth')
 
       fakeDashboardClient = {}
       builder = LookerEmbedSDK.createDashboardWithUrl(testUrl)
@@ -160,10 +194,6 @@ describe('LookerEmbed', () => {
         iframe = this.iframe
         return Promise.resolve({})
       })
-    })
-
-    afterEach(() => {
-      document.body.removeChild(el)
     })
 
     it('it should create an iframe with the appropriate parameters', (done) => {


### PR DESCRIPTION
Fixes https://github.com/looker-open-source/embed-sdk/issues/10