### PR TITLE
Update packages, ship individual js files for typescript.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 .vscode
 __pycache__
 *.pyc
+*.tgz
 coverage
 demo/demo.js
 dist

--- a/package-lock.json
+++ b/package-lock.json
@@ -179,9 +179,9 @@
       }
     },
     "@looker/chatty": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.0.0.tgz",
-      "integrity": "sha512-4SPR25/TJpKbkps/KItzM98R+VmyMTYlmN77o9plPvC9riDSiBPr9hjCuddbj7E2jDA1VvXmwe0uc1yNdn7ULg==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@looker/chatty/-/chatty-2.2.0.tgz",
+      "integrity": "sha512-+4KJI0ACVFX/r7KY4MyTXOqbEq0sSV+n8N2hRA0Kq+FJ6VxM5PpwSG8R5QEe4MuT3hNMV3H/kkX2NlFMvtnS8w==",
       "requires": {
         "core-js": "^3.1.4",
         "debug": "^2.2.0",
@@ -189,9 +189,9 @@
       },
       "dependencies": {
         "core-js": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
-          "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+          "version": "3.3.6",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.3.6.tgz",
+          "integrity": "sha512-u4oM8SHwmDuh5mWZdDg9UwNVq5s1uqq6ZDLLIs07VY+VJU91i3h4f3K/pgFvtUQPGdeStrZ+odKyfyt4EnKHfA=="
         }
       }
     },
@@ -4049,9 +4049,9 @@
       "dev": true
     },
     "handlebars": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.1.2.tgz",
-      "integrity": "sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==",
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.1.tgz",
+      "integrity": "sha512-C29UoFzHe9yM61lOsIlCE5/mQVGrnIOrOq7maQl76L7tYPCgC1og0Ajt6uWnX4ZTxBPnjw+CUvawphwCfJgUnA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -8098,16 +8098,23 @@
       }
     },
     "uglify-js": {
-      "version": "3.5.10",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.5.10.tgz",
-      "integrity": "sha512-/GTF0nosyPLbdJBd+AwYiZ+Hu5z8KXWnO0WCGt1BQ/u9Iamhejykqmz5o1OHJ53+VAk6xVxychonnApDjuqGsw==",
+      "version": "3.6.8",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.6.8.tgz",
+      "integrity": "sha512-XhHJ3S3ZyMwP8kY1Gkugqx3CJh2C3O0y8NPiSxtm1tyD/pktLAkFZsFGpuNfTZddKDQ/bbDBLAd2YyA1pbi8HQ==",
       "dev": true,
       "optional": true,
       "requires": {
-        "commander": "~2.20.0",
+        "commander": "~2.20.3",
         "source-map": "~0.6.1"
       },
       "dependencies": {
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true,
+          "optional": true
+        },
         "source-map": {
           "version": "0.6.1",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@looker/embed-sdk",
   "version": "1.0.0-beta.3",
   "description": "A toolkit for embedding Looker",
-  "main": "dist/main.js",
+  "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "directories": {
     "test": "tests"
@@ -17,14 +17,14 @@
     "src/**/*"
   ],
   "scripts": {
-    "build": "npm run clean && npm run build_utils && webpack",
+    "build": "npm run clean && npm run build_utils && tsc && webpack",
     "build_utils": "tsc --build tsconfig-server.json",
     "clean": "rm -rf lib dist",
     "docs": "typedoc --mode file --out docs",
     "lint": "tslint --project tsconfig-lint.json --format stylish",
     "lint-fix": "tslint --fix --project tsconfig-lint.json  --format stylish",
     "start": "npm run build_utils && webpack-dev-server --config webpack-devserver.config.js --hot --inline --open --color --progress",
-    "prepublish": "npm run build",
+    "prepare": "npm run build",
     "prepublishOnly": "npm run test-once",
     "python": "webpack --config webpack-devserver.config.js && python demo/demo.py",
     "test": "npm run lint && karma start karma.conf.js",
@@ -69,7 +69,7 @@
     "xhr-mock": "^2.4.1"
   },
   "dependencies": {
-    "@looker/chatty": "^2.0.0"
+    "@looker/chatty": "^2.2.0"
   },
   "pre-commit": [
     "test-once"


### PR DESCRIPTION
Still feeling my way around the best way to package everything, this seems to provide the best compatibility with Typescript and mirrors how we're doing it with Chatty. We still ship a bundled version but it would have to be manually referenced.