### PR TITLE
Allow embeds to be instantiated in a sandboxed host which may be host…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/embed-sdk",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3392,8 +3392,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -3414,14 +3413,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -3436,20 +3433,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3566,8 +3560,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3579,7 +3572,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3594,7 +3586,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3602,14 +3593,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3628,7 +3617,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3709,8 +3697,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3722,7 +3709,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3808,8 +3794,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3845,7 +3830,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3865,7 +3849,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3909,14 +3892,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/embed-sdk",
-  "version": "1.0.0-beta.4",
+  "version": "1.0.0-beta.5",
   "description": "A toolkit for embedding Looker",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -62,6 +62,9 @@ export class EmbedClient<T> {
   }
 
   get targetOrigin () {
+    if (this._builder.sandboxedHost) {
+      return '*'
+    }
     const apiHost = this._builder.apiHost
     return IS_URL.test(apiHost) ? apiHost : `https://${apiHost}`
   }
@@ -97,7 +100,7 @@ export class EmbedClient<T> {
 
   private async createUrl () {
     const src = this._builder.embedUrl
-    if (!this._builder.authUrl) return src
+    if (!this._builder.authUrl) return `${this._builder.apiHost}${src}`
 
     const url = `${this._builder.authUrl}?src=${encodeURIComponent(src)}`
 

--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -64,6 +64,7 @@ export class EmbedBuilder<T> {
   private _params: UrlParams
   private _suffix: string = ''
   private _url?: string | null
+  private _sandboxedHost?: boolean
 
   /**
    * @hidden
@@ -74,10 +75,18 @@ export class EmbedBuilder<T> {
     private _type: string,
     private _clientConstructor: EmbedClientConstructor<T>
   ) {
-    const embedDomain = window.location.origin
-    this._params = {
-      embed_domain: embedDomain,
-      sdk: '2'
+    if (this.sandboxedHost) {
+      this._params = {
+        embed_domain: this._hostSettings.apiHost,
+        sdk: '2',
+        sandboxed_host: 'true'
+      }
+    } else {
+      const embedDomain = window.location.origin
+      this._params = {
+        embed_domain: embedDomain,
+        sdk: '2'
+      }
     }
   }
 
@@ -186,6 +195,26 @@ export class EmbedBuilder<T> {
   withUrl (url: string) {
     this._url = url
     return this
+  }
+
+  /**
+   * @hidden
+   */
+
+  set sandboxedHost (sandboxedHost: boolean) {
+    this._sandboxedHost = sandboxedHost
+  }
+
+  /**
+   * @hidden
+   */
+
+  get sandboxedHost () {
+    if (!this._sandboxedHost) {
+      const embedHostDomain = window.location.origin
+      this._sandboxedHost = embedHostDomain === 'null' || !embedHostDomain
+    }
+    return this._sandboxedHost
   }
 
   /**

--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -210,7 +210,7 @@ export class EmbedBuilder<T> {
    */
 
   get sandboxedHost () {
-    if (!this._sandboxedHost) {
+    if (this._sandboxedHost === undefined) {
       const embedHostDomain = window.location.origin
       this._sandboxedHost = embedHostDomain === 'null' || !embedHostDomain
     }

--- a/tests/embed.spec.ts
+++ b/tests/embed.spec.ts
@@ -210,6 +210,36 @@ describe('LookerEmbed', () => {
     })
   })
 
+  describe('creating an iframe in a sandboxed environment', () => {
+    let fakeDashboardClient
+    let iframe: HTMLIFrameElement
+
+    beforeEach(() => {
+      spyOn(EmbedBuilder.prototype, 'sandboxedHost').and.returnValue(true)
+      spyOn(window, 'fetch')
+      spyOn(ChattyHost.prototype, 'connect').and.callFake(async function (this: any) {
+        iframe = this.iframe
+        return Promise.resolve({})
+      })
+
+      LookerEmbedSDK.init('https://host.looker.com:9999')
+      fakeDashboardClient = {}
+      builder = LookerEmbedSDK.createDashboardWithId(11)
+      builder.appendTo('#the-element')
+      client = builder.build()
+    })
+
+    it('prefixes iframe src with host url and sets targetOrigin to *', (done) => {
+      client.connect()
+        .then(() => {
+          expect(client.targetOrigin).toEqual('*')
+          expect(iframe.src).toEqual('https://host.looker.com:9999/embed/dashboards/11?embed_domain=https%3A%2F%2Fhost.looker.com%3A9999&sdk=2&sandboxed_host=true')
+          done()
+        })
+        .catch(done.fail)
+    })
+  })
+
   describe('receiving messages', () => {
     let mockDashboardClient: any
     let embedDashboard: any


### PR DESCRIPTION
…ed in a looker instance.

The iframe source is now prefixed with the looker instance URL if the auth URL is not provided.

If the embed API determines that it is running in a sandbox, it sets the target origin for the initial postMessage to '*' (otherwise a failure will occur on the postMessage).

New helper methods have been added to the embed builder to determine if the host of the embed is running in sandboxed iframe