### PR TITLE
Support for an embedded query with explore_id and client_id

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -134,13 +134,13 @@ export class LookerEmbedSDK {
   /**
    * Create an EmbedBuilder for an embedded Looker query.
    *
-   * @param explore_id The ID of a Looker explore
-   * @param client_id The client_id / qid / slug of a Looker query
+   * @param exploreId The ID of a Looker explore
+   * @param clientId The client_id / qid / slug of a Looker query
    */
 
-  static createQueryWithClientId (explore_id: string, client_id: string) {
-    explore_id = explore_id.replace('::', '/') // Handle old format explore ids.
-    return new EmbedBuilder<LookerEmbedQuery>(this, 'query', '/embed/query', LookerEmbedQuery).withId(explore_id).withParams({qid: client_id})
+  static createQueryWithClientId (exploreId: string, clientId: string) {
+    exploreId = exploreId.replace('::', '/') // Handle old format explore ids.
+    return new EmbedBuilder<LookerEmbedQuery>(this, 'query', '/embed/query', LookerEmbedQuery).withId(exploreId).withParams({ qid: clientId })
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,11 +27,13 @@ import { LookerEmbedDashboard } from './dashboard_client'
 import { LookerEmbedExplore } from './explore_client'
 import { LookerEmbedExtension } from './extension_client'
 import { LookerEmbedLook } from './look_client'
+import { LookerEmbedQuery } from './query_client'
 
 export type { LookerEmbedDashboard } from './dashboard_client'
 export type { LookerEmbedExplore } from './explore_client'
 export type { LookerEmbedExtension } from './extension_client'
 export type { LookerEmbedLook } from './look_client'
+export type { LookerEmbedQuery } from './query_client'
 
 export class LookerEmbedSDK {
 
@@ -127,6 +129,18 @@ export class LookerEmbedSDK {
 
   static createExtensionWithId (id: string) {
     return new EmbedBuilder<LookerEmbedExtension>(this, 'extension', '/embed/extensions', LookerEmbedExtension).withId(id)
+  }
+
+  /**
+   * Create an EmbedBuilder for an embedded Looker query.
+   *
+   * @param explore_id The ID of a Looker explore
+   * @param client_id The client_id / qid / slug of a Looker query
+   */
+
+  static createQueryWithClientId (explore_id: string, client_id: string) {
+    explore_id = explore_id.replace('::', '/') // Handle old format explore ids.
+    return new EmbedBuilder<LookerEmbedQuery>(this, 'query', '/embed/query', LookerEmbedQuery).withId(explore_id).withParams({qid: client_id})
   }
 
   /**

--- a/src/query_client.ts
+++ b/src/query_client.ts
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { LookerEmbedFilterParams } from './types'
+import { LookerEmbedBase } from './embed_base'
+
+/**
+ * Client that communicates with an embedded Looker Look. Messages are documented
+ * [here](https://docs.looker.com/r/sdk/events)
+ */
+
+export class LookerEmbedQuery extends LookerEmbedBase {
+  /**
+   * Convenience method for sending a run message to the embedded Look.
+   */
+
+  run () {
+    this.send('look:run')
+  }
+
+  /**
+   * Convenience method for updating the filters of the embedded Look.
+   *
+   * @param filters A set of filter parameters to update
+   */
+
+  updateFilters (params: LookerEmbedFilterParams) {
+    this.send('look:filters:update', { filters: params })
+  }
+}

--- a/tests/query_client.spec.ts
+++ b/tests/query_client.spec.ts
@@ -48,11 +48,11 @@ describe('LookerEmbedQuery', () => {
 
   it('it runs', () => {
     client.run()
-    expect(sendSpy).toHaveBeenCalledWith('explore:run', undefined)
+    expect(sendSpy).toHaveBeenCalledWith('look:run', undefined)
   })
 
   it('it sets filters', () => {
     client.updateFilters({ 'alpha': 'beta' })
-    expect(sendSpy).toHaveBeenCalledWith('explore:filters:update', { filters: { 'alpha': 'beta' } })
+    expect(sendSpy).toHaveBeenCalledWith('look:filters:update', { filters: { 'alpha': 'beta' } })
   })
 })

--- a/tests/query_client.spec.ts
+++ b/tests/query_client.spec.ts
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Looker Data Sciences, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+import { LookerEmbedQuery } from '../src/query_client'
+import { ChattyHostConnection } from '@looker/chatty'
+
+describe('LookerEmbedQuery', () => {
+  let sendSpy: jasmine.Spy
+  let sendAndReceiveSpy: jasmine.Spy
+  let host: ChattyHostConnection
+  let client: LookerEmbedQuery
+
+  beforeEach(() => {
+    sendSpy = jasmine.createSpy()
+    sendAndReceiveSpy = jasmine.createSpy()
+    host = {
+      send: sendSpy,
+      sendAndReceive: sendAndReceiveSpy
+    }
+    client = new LookerEmbedQuery(host)
+  })
+
+  it('it relays messages', () => {
+    client.send('a:message', { some: 'params' })
+    expect(sendSpy).toHaveBeenCalledWith('a:message', { some: 'params' })
+  })
+
+  it('it runs', () => {
+    client.run()
+    expect(sendSpy).toHaveBeenCalledWith('explore:run', undefined)
+  })
+
+  it('it sets filters', () => {
+    client.updateFilters({ 'alpha': 'beta' })
+    expect(sendSpy).toHaveBeenCalledWith('explore:filters:update', { filters: { 'alpha': 'beta' } })
+  })
+})


### PR DESCRIPTION
Looker has an embedded query object that is similar to a look but doesn't require saved content like a look. The most common use case is take a visualization from an explore and the client_id (qid) and use it in `/embed/query` like `https://customer.looker.com/embed/query/model_name/explore_name?qid=rZ8tfkWrsxtRwGbi46g8L0`.

The PR introduces createQueryWithClientId (exploreId: string, clientId: string) to facilitate embedding these query objects.