### PR TITLE
#14 Added the ability to send headers to SSO server

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -98,7 +98,7 @@ export class EmbedClient<T> {
       })
   }
 
-  private async createUrl () {
+  private async createUrl (headers?: Array<{ name: string, value: string }>) {
     const src = this._builder.embedUrl
     if (!this._builder.authUrl) return `${this._builder.apiHost}${src}`
 
@@ -108,7 +108,13 @@ export class EmbedClient<T> {
       // compute signature
       const xhr = new XMLHttpRequest()
       xhr.open('GET', url)
+      if (headers) {
+        headers.forEach((header) => {
+          xhr.setRequestHeader(header.name, header.value)
+        })
+      }
       xhr.setRequestHeader('Cache-Control', 'no-cache')
+
       xhr.onload = () => {
         if (xhr.status === 200) {
           resolve(JSON.parse(xhr.responseText).url)
@@ -132,7 +138,7 @@ export class EmbedClient<T> {
     if (this._builder.url) {
       this._connection = this.createIframe(this._builder.url)
     } else {
-      this._connection = this.createUrl().then(async (url) => this.createIframe(url))
+      this._connection = this.createUrl(this._builder.headers).then(async (url) => this.createIframe(url))
     }
     return this._connection
   }

--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -31,6 +31,7 @@ type EmbedClientConstructor<T> = { new(host: ChattyHostConnection): T ;}
 interface LookerEmbedHostSettings {
   apiHost: string
   authUrl?: string
+  headers?: Array<{ name: string, value: string }>
 }
 
 interface UrlParams {
@@ -307,6 +308,14 @@ export class EmbedBuilder<T> {
 
   get authUrl () {
     return this._hostSettings.authUrl
+  }
+
+  /**
+   * The auth headers of this embedded content, if provided
+   */
+
+  get headers () {
+    return this._hostSettings.headers
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,11 +42,13 @@ export class LookerEmbedSDK {
    * @param apiHost The address or base URL of the Looker host (example.looker.com:9999, https://example.looker.com:9999)
    *                This is required for verification of messages sent from the embedded content.
    * @param authUrl A server endpoint that will sign SSO embed URLs
+   * @param headers An array of HTTP headers that are providing to authUrl
    */
 
-  static init (apiHost: string, authUrl?: string) {
+  static init (apiHost: string, authUrl?: string, headers?: Array<{ name: string, value: string }>) {
     this.apiHost = apiHost
     this.authUrl = authUrl
+    this.headers = headers
   }
 
   /**
@@ -141,4 +143,10 @@ export class LookerEmbedSDK {
    */
 
   static authUrl?: string
+
+  /**
+   * @hidden
+   */
+
+  static headers?: Array<{ name: string, value: string }>
 }


### PR DESCRIPTION
Added the ability to provide headers to SSO server:
```
const headers = [];
headers['Authorization'] = 'UPDATE_ME';

LookerEmbedSDK.init('looker.example.com', '/auth', headers);
```