### PR TITLE
Add `withCredentials` option to the `auth` config to support CORS

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ The Auth endpoint can be configured further, allowing custom Request Headers, as
 LookerEmbedSDK.init('looker.example.com', 
   {
     url: 'https://api.acme.com/looker/auth',
-    headers: { 'Foo Header': 'Foo' },
-    params: { foo: 'bar' },
+    headers: [{'name': 'Foo Header', 'value': 'Foo'}],
+    params: [{'name': 'foo', 'value': 'bar'}],
     withCredentials: true // Needed for CORS requests to Auth endpoint include Http Only cookie headers
   })
 ``` 
@@ -299,4 +299,3 @@ Note that both the parent window and the embedded content have separate local st
 ```javascript
 localStorage.debug = ''
 ```
-

--- a/README.md
+++ b/README.md
@@ -123,6 +123,19 @@ This will call the /looker_auth endpoint and return a signed SSO URL that can be
 src=https://looker.example.com/embed/dashboards/11?sdk=2&embed_host=https://yourhost.example.com
 ```
 
+### Advanced Auth Configuration
+The Auth endpoint can be configured further, allowing custom Request Headers, as well as CORS support by passing an options object to the `init` method 
+
+```javascript
+LookerEmbedSDK.init('looker.example.com', 
+  {
+    url: 'https://api.acme.com/looker/auth',
+    headers: { 'Foo Header': 'Foo' },
+    params: { foo: 'bar' },
+    withCredentials: true // Needed for CORS requests to Auth endpoint include Http Only cookie headers
+  })
+``` 
+
 ### Node helper
 
 A signing helper method `createSignedUrl()` is provided in

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -114,6 +114,9 @@ export class EmbedClient<T> {
       // compute signature
       const xhr = new XMLHttpRequest()
       xhr.open('GET', url)
+      if (auth.withCredentials) {
+        xhr.withCredentials = auth.withCredentials
+      }
       xhr.setRequestHeader('Cache-Control', 'no-cache')
       if (auth.headers) {
         for (const header of auth.headers) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,6 +33,7 @@ export interface LookerAuthConfig {
   url: string
   headers?: Array<{name: string, value: string}>
   params?: Array<{name: string, value: string}>
+  withCredentials?: boolean
 }
 
 /**

--- a/tests/embed_builder.spec.ts
+++ b/tests/embed_builder.spec.ts
@@ -375,6 +375,18 @@ describe('LookerEmbedBuilder', () => {
       expect(embedSdk.auth).toEqual(authConfig)
     })
 
+    it('builder allows withCredentials auth config to be set', () => {
+      const authWithCredentials = {
+        ...authConfig,
+        withCredentials: true
+      }
+      LookerEmbedSDK.createDashboardWithUrl('https://host.looker.com:9999/login/embed/etc')
+          .withApiHost(host)
+          .withAuth(authWithCredentials)
+      expect(embedSdk.apiHost).toEqual(host)
+      expect(embedSdk.auth).toEqual(authWithCredentials)
+    })
+
     it('prevents api host and auth config from being overridden', () => {
       LookerEmbedSDK.init(host, authConfig)
       try {


### PR DESCRIPTION
## [Issue](Implementation of https://github.com/looker-open-source/embed-sdk/issues/67)
Currently, there is no way to indicate to tell the Embed SDK to include Http Only request headers in the Auth endpoint `XmlHttpRequest` that is created to authenticate a user and generate a signed SSO embed url when the auth endpoint lives on a different domain than the host site. 

## Solution
This PR adds a `withCredentials` configuration option to the existing `auth` config object, allowing the user to set `xhr.withCredentials = true`, which will allow secure Http Only Cookies to set request headers on the auth requests. 