### PR TITLE
Add new embed message types

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -113,6 +113,9 @@ document.addEventListener('DOMContentLoaded', function () {
       .on('dashboard:loaded', () => updateState('#dashboard-state', 'Loaded'))
       .on('dashboard:run:start', () => updateState('#dashboard-state', 'Running'))
       .on('dashboard:run:complete', () => updateState('#dashboard-state', 'Done'))
+      // Listen to messages that change dashboard
+      .on('dashboard:save:complete', () => updateState('#dashboard-state', 'Saved'))
+      .on('dashboard:delete:complete', () => updateState('#dashboard-state', 'Deleted'))
       // Listen to messages to prevent the user from navigating away
       .on('drillmenu:click', canceller)
       .on('drillmodal:explore', canceller)
@@ -147,6 +150,9 @@ document.addEventListener('DOMContentLoaded', function () {
       .on('look:ready', () => updateState('#look-state', 'Loaded'))
       .on('look:run:start', () => updateState('#look-state', 'Running'))
       .on('look:run:complete', () => updateState('#look-state', 'Done'))
+      // Listen to messages that change Look
+      .on('look:save:complete', () => updateState('#look-state', 'Saved'))
+      .on('look:delete:complete', () => updateState('#look-state', 'Deleted'))
       // Give the embedded content a class for styling purposes
       .withClassName('looker-embed')
       // Set the initial filters

--- a/src/types.ts
+++ b/src/types.ts
@@ -315,6 +315,8 @@ export interface LookerEmbedEventMap {
   'dashboard:run:start': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:run:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:filters:changed': (this: LookerEmbedDashboard, event: DashboardEvent) => void
+  'dashboard:save:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
+  'dashboard:delete:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:tile:start': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
   'dashboard:tile:complete': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
   'dashboard:tile:download': (this: LookerEmbedDashboard, event: DashboardTileDownloadEvent) => void
@@ -331,6 +333,8 @@ export interface LookerEmbedEventMap {
 
   'look:run:start': (this: LookerEmbedLook, event: LookEvent) => void
   'look:run:complete': (this: LookerEmbedLook, event: LookEvent) => void
+  'look:save:complete': (this: LookerEmbedLook, event: LookEvent) => void
+  'look:delete:complete': (this: LookerEmbedLook, event: LookEvent) => void
   'look:ready': (this: LookerEmbedLook, event: LookEvent) => void
   'look:state:changed': (this: LookerEmbedLook, event: LookEvent) => void
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -257,6 +257,27 @@ export interface LookEvent extends LookerEmbedEvent {
 }
 
 /**
+ * Look save event details
+ * Looker version 21.6
+ */
+
+export interface LookSaveEventDetail extends LookEventDetail {
+  /**
+   * Folder Look is associated with
+   * Looker version 21.8
+   */
+  spaceId: number
+}
+
+/**
+ * Look save event
+ * Looker version 21.6
+ */
+export interface LookSaveEvent extends LookerEmbedEvent {
+  look: LookSaveEventDetail
+}
+
+/**
  * Explore page event details
  */
 
@@ -308,14 +329,22 @@ export interface CancellableEventResponse {
 }
 
 /**
- * Current Looker embed events as of version 6.20
+ * Current Looker embed events as of version 6.20 (except where stated)
  */
 
 export interface LookerEmbedEventMap {
   'dashboard:run:start': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:run:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:filters:changed': (this: LookerEmbedDashboard, event: DashboardEvent) => void
+  /**
+   * Dashboard saved event
+   * Looker 21.6
+   */
   'dashboard:save:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
+  /**
+   * Dashboard deleted event
+   * Looker 21.6
+   */
   'dashboard:delete:complete': (this: LookerEmbedDashboard, event: DashboardEvent) => void
   'dashboard:tile:start': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
   'dashboard:tile:complete': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
@@ -333,8 +362,16 @@ export interface LookerEmbedEventMap {
 
   'look:run:start': (this: LookerEmbedLook, event: LookEvent) => void
   'look:run:complete': (this: LookerEmbedLook, event: LookEvent) => void
-  'look:save:complete': (this: LookerEmbedLook, event: LookEvent) => void
-  'look:delete:complete': (this: LookerEmbedLook, event: LookEvent) => void
+  /**
+   * Look saved event
+   * Looker 21.6
+   */
+  'look:save:complete': (this: LookerEmbedLook, event: LookSaveEvent) => void
+  /**
+   * Look deleted event
+   * Looker 21.6
+   */
+  'look:delete:complete': (this: LookerEmbedLook, event: LookSaveEvent) => void
   'look:ready': (this: LookerEmbedLook, event: LookEvent) => void
   'look:state:changed': (this: LookerEmbedLook, event: LookEvent) => void
 


### PR DESCRIPTION
dashboard:save:complete - fired when edited dashboard-next is saved
dashboard:delete:complete - fired when dashboard-next is deleted
look:save:complete - fired when edited look is saved
look:delete:complete - fired when look is deleted