### PR TITLE
type definitions for dashboard next tile errors

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -59,7 +59,9 @@ const setupDashboard = (dashboard: LookerEmbedDashboard) => {
   const stateFilter = document.querySelector('#state')
   if (stateFilter) {
     stateFilter.addEventListener('change', (event) => {
-      dashboard.updateFilters({ 'State / Region': (event.target as HTMLSelectElement).value })
+      dashboard.updateFilters({
+        'State / Region': (event.target as HTMLSelectElement).value,
+      })
     })
   }
 }
@@ -77,7 +79,9 @@ const setupLookOrExplore = (look: LookerEmbedLook) => {
   const stateFilter = document.querySelector('#state')
   if (stateFilter) {
     stateFilter.addEventListener('change', (event) => {
-      look.updateFilters({ 'users.state': (event.target as HTMLSelectElement).value })
+      look.updateFilters({
+        'users.state': (event.target as HTMLSelectElement).value,
+      })
     })
   }
 }
@@ -103,7 +107,6 @@ const canceller = (event: any) => {
 // all the parent elements are present.
 
 document.addEventListener('DOMContentLoaded', function () {
-
   // Create an embedded dashboard
   if (dashboardId) {
     LookerEmbedSDK.createDashboardWithId(dashboardId)
@@ -123,7 +126,7 @@ document.addEventListener('DOMContentLoaded', function () {
       .on('dashboard:tile:view', canceller)
       // Give the embedded content a class for styling purposes
       .withClassName('looker-embed')
-       // Enable Dashboards Beta
+      // Enable Dashboards Next
       .withNext()
       // Set the initial filters
       .withFilters({ 'State / Region': 'California' })
@@ -198,7 +201,7 @@ document.addEventListener('DOMContentLoaded', function () {
     document.querySelector<HTMLDivElement>('#demo-explore')!.style.display = 'none'
   }
 
-  // Create an embedded extension (Requires Looker 7.12 and extensions beta)
+  // Create an embedded extension (Requires Looker 7.12 and extensions framework)
   if (extensionId) {
     LookerEmbedSDK.createExtensionWithId(extensionId)
       // Append to the #extension element

--- a/demo/demo_config.ts
+++ b/demo/demo_config.ts
@@ -16,5 +16,5 @@ export const exploreId = 'thelook::orders'
 
 // An Extension that the user can see. Set to '' to disable extension demo.
 // export const extensionId = 'extension::my-great-extension'
-// Requires Looker 7.12 and extensions beta.
+// Requires Looker 7.12 and extensions framework.
 export const extensionId = ''

--- a/src/dashboard_client.ts
+++ b/src/dashboard_client.ts
@@ -42,7 +42,7 @@ export class LookerEmbedDashboard extends LookerEmbedBase {
   /**
    * Convenience method for sending a stop message to the embedded dashboard.
    *
-   * Requires Looker 7.14 and Dashboards (Beta) (see [[EmbedBuilder.withNext]]).
+   * Requires Looker 7.14 and Dashboards Next (see [[EmbedBuilder.withNext]]).
    */
 
   stop () {
@@ -72,7 +72,7 @@ export class LookerEmbedDashboard extends LookerEmbedBase {
   /**
    * Convenience method for opening the dashboard schedule dialog.
    *
-   * Requires Looker 7.18 and Dashboards (Beta) (see [[EmbedBuilder.withNext]]).
+   * Requires Looker 7.18 and Dashboards Next (see [[EmbedBuilder.withNext]]).
    */
 
   async openScheduleDialog (): Promise<void> {
@@ -81,7 +81,7 @@ export class LookerEmbedDashboard extends LookerEmbedBase {
 
   /**
    * Convenience method for loading a new dashboard.
-   * Requires Looker 7.12 and Dashboards (Beta) (see [[EmbedBuilder.withNext]]).
+   * Requires Looker 7.12 and Dashboards Next (see [[EmbedBuilder.withNext]]).
    * Throws an error if the dashboard load did not happen, which can happen if the
    * current dashboard is in edit mode.
    *

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,8 +31,8 @@ import { LookerEmbedLook } from './look_client'
  */
 export interface LookerAuthConfig {
   url: string
-  headers?: Array<{name: string, value: string}>
-  params?: Array<{name: string, value: string}>
+  headers?: Array<{ name: string; value: string }>
+  params?: Array<{ name: string; value: string }>
   withCredentials?: boolean
 }
 
@@ -151,7 +151,21 @@ export interface DashboardEventDetail extends EventDetail {
 export interface DashboardTileEventDetail extends EventDetail {
   id: string | number
   title: string
-  listen: string
+  listen: Record<string, string | null>
+}
+
+/**
+ * Dashboard tile status
+ *
+ * Available on Dashboards Next
+ *
+ * Requires Looker 21.14
+ */
+
+export interface TileStatus {
+  tileId: string
+  status: 'error' | 'complete'
+  errors?: Array<QueryError>
 }
 
 /**
@@ -160,8 +174,29 @@ export interface DashboardTileEventDetail extends EventDetail {
 
 export interface DashboardEvent extends LookerEmbedEvent {
   dashboard: DashboardEventDetail
-  /// Available on Dashboards Beta
+  /// Available on Dashboards Next
   status?: 'complete' | 'error' | 'stopped'
+  /// Available on Dashboards Next
+  /// Requires Looker 21.14
+  tileStatuses: Array<TileStatus>
+}
+
+/**
+ * Query error detail
+ *
+ * Requires Looker 21.14
+ */
+
+export interface QueryError {
+  message: string | null
+  message_details: string | null
+  params: string | null
+  error_pos: string | null
+  level: string
+  fatal?: boolean
+  sql_error_loc: {
+    [key: string]: any
+  }
 }
 
 /**
@@ -171,10 +206,13 @@ export interface DashboardEvent extends LookerEmbedEvent {
 export interface DashboardTileEvent {
   dashboard: DashboardEventDetail
   tile: DashboardTileEventDetail
-  /// Available on Dashboards Beta
+  /// Available on Dashboards Next
   status?: 'complete' | 'error'
-  /// Available on Dashboards Beta
+  /// Available on Dashboards Next
   truncated?: boolean
+  /// Available on Dashboards Next
+  /// Requires Looker 21.14
+  errors?: Array<QueryError>
 }
 
 /**
@@ -349,8 +387,14 @@ export interface LookerEmbedEventMap {
   'dashboard:tile:start': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
   'dashboard:tile:complete': (this: LookerEmbedDashboard, event: DashboardTileEvent) => void
   'dashboard:tile:download': (this: LookerEmbedDashboard, event: DashboardTileDownloadEvent) => void
-  'dashboard:tile:explore': (this: LookerEmbedDashboard, event: DashboardTileExploreEvent) => CancellableEventResponse | undefined
-  'dashboard:tile:view': (this: LookerEmbedDashboard, event: DashboardTileViewEvent) => CancellableEventResponse | undefined
+  'dashboard:tile:explore': (
+    this: LookerEmbedDashboard,
+    event: DashboardTileExploreEvent
+  ) => CancellableEventResponse | undefined
+  'dashboard:tile:view': (
+    this: LookerEmbedDashboard,
+    event: DashboardTileViewEvent
+  ) => CancellableEventResponse | undefined
 
   'drillmenu:click': (this: LookerEmbedBase, event: DrillMenuEvent) => CancellableEventResponse | undefined
   'drillmodal:explore': (this: LookerEmbedBase, event: DrillModalExploreEvent) => CancellableEventResponse | undefined


### PR DESCRIPTION
1. Additional types for new properties added to dashboard:run:complete and dashboard:tile:complete events. 
2. Change references to Dashboards Beta to Dashboards Next
3. Change references to extensions beta to extensions framework.
4. Fix type for listen property.