### PR TITLE
Add six to python backend requirements.txt

### DIFF
--- a/demo/requirements.txt
+++ b/demo/requirements.txt
@@ -1,1 +1,2 @@
 looker-sdk
+six


### PR DESCRIPTION
We use "six" package for Python 2/3 compatibility. Python dependencies
like looker sdk are already automatically installed by `yarn run python`
so we should also install six at the same time to make the python
backend easy to setup. My first time running it failed because six was
not installed.