### PR TITLE
Updated doc gen workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,10 +13,10 @@ jobs:
     steps:
     - uses: actions/checkout@v1
 
-    - name: Use Node.js ${{ NODE_VERSION }}
+    - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
       with:
-        node-version: ${{ NODE_VERSION }}
+        node-version: ${{ env.NODE_VERSION }}
 
     - name: Install dependencies
       run: npm ci


### PR DESCRIPTION
Github can't parse the workflow because of environment variable bug.
Fixed the bug.

And now I am locally linting the workflow, because nektos/act can successfully
run workflows that github fails to parse.