### PR TITLE
feat: demo cookieless embed error handling

### DIFF
--- a/demo/demo.css
+++ b/demo/demo.css
@@ -23,11 +23,11 @@ body {
   }
 }
 select {
-  width: 150px;
+  min-width: 150px;
   height: 25px;
 }
 button {
-  width: 100px;
+  min-width: 100px;
   height: 25px;
 }
 .loading-message {
@@ -49,6 +49,10 @@ button {
 }
 .embed-header {
   height: 65px;
+  width: 100%;
+}
+.error-controls {
+  height: 40px;
   width: 100%;
 }
 .looker-embed {

--- a/demo/message_example.html
+++ b/demo/message_example.html
@@ -49,6 +49,12 @@
     </div>
     <div class="embed-container">
       <div id="demo-dashboard">
+        <div class="error-controls">
+          <button id="error-1">Unrecoverable error</button>
+          <button id="error-2">Recoverable error</button>
+          <button id="error-3">Send bad tokens</button>
+          <button id="error-4">Send session expired</button>
+        </div>
         <div class="embed-header">
           <button id="run-dashboard">Run</button>
           <button id="stop-dashboard">Stop</button>

--- a/demo/message_example.ts
+++ b/demo/message_example.ts
@@ -456,7 +456,7 @@ const initializeErrorControls = (runtimeConfig: RuntimeConfig) => {
               // it is not. The Looker application is going to timeout because
               // it fails to get a handshake. This is considered a coding error
               // on the part of the embedding application (this) and is unrecoverable.
-              // Not that the Looker displays an explanatory message in the console.
+              // Note that the Looker application displays an explanatory message in the console.
               renderDashboard({ ...runtimeConfig }, '?sdk=2')
             }, 500)
           })

--- a/demo/message_utils.ts
+++ b/demo/message_utils.ts
@@ -262,7 +262,9 @@ class EmbedFrameImpl implements EmbedFrame {
     public readonly iframeId: string,
     public readonly embedUrl: string,
     public readonly parentElementId?: string,
-    public readonly className?: string
+    public readonly className?: string,
+    // Demo code for testing error conditions. NOT REQUIRED for production applications.
+    private recoverableError?: boolean
   ) {
     const element = document.getElementById(iframeId)
     if (parentElementId) {
@@ -458,6 +460,8 @@ class EmbedFrameImpl implements EmbedFrame {
     return signedUrl
   }
 
+  private countTokenRequests = 0
+
   /**
    * Handler for token requests (cookieless embed only)
    */
@@ -465,6 +469,13 @@ class EmbedFrameImpl implements EmbedFrame {
     const contentWindow = this.getContentWindow()
     if (contentWindow) {
       if (!this.connected) {
+        // Demo code for testing error conditions. NOT REQUIRED for production applications.
+        if (this.recoverableError) {
+          this.countTokenRequests++
+          if (this.countTokenRequests < 4) {
+            return
+          }
+        }
         // When not connected the newly acquired tokens can be used.
         const sessionTokens = this.embedEnvironment.applicationTokens
         if (sessionTokens) {
@@ -560,7 +571,9 @@ export const addEmbedFrame = (
   iframeId: string,
   embedUrl: string,
   parentElementId?: string,
-  className?: string
+  className?: string,
+  // Demo code for testing error conditions. NOT REQUIRED for production applications.
+  recoverableError?: boolean
 ): EmbedFrame => {
   if (embedFrames.has(iframeId)) {
     deleteEmbedFrame(iframeId)
@@ -570,7 +583,8 @@ export const addEmbedFrame = (
     iframeId,
     embedUrl,
     parentElementId,
-    className
+    className,
+    recoverableError
   )
   embedFrames.set(iframeId, frame)
   return frame


### PR DESCRIPTION
Adds buttons to the postMessage demo that trigger error scenerios. Two buttons have been implemented in this PR
1. recoverable.
2. non recoverable.