### PR TITLE
feat: cookieless embed error handling demo

### DIFF
--- a/demo/message_example.ts
+++ b/demo/message_example.ts
@@ -36,6 +36,7 @@ import {
   addEmbedFrame,
   deleteEmbedFrame,
   getEmbedFrame,
+  getApplicationTokens,
 } from './message_utils'
 import type { RuntimeConfig } from './demo_config'
 import {
@@ -476,6 +477,26 @@ const initializeErrorControls = (runtimeConfig: RuntimeConfig) => {
               // be ignored.
               renderDashboard({ ...runtimeConfig }, '', true)
             }, 500)
+          })
+        }
+        // Simulate bad tokens
+        const error3 = document.getElementById('error-3') as HTMLButtonElement
+        if (error3) {
+          error3.addEventListener('click', () => {
+            getEmbedFrame(getDashboardFrameId(runtimeConfig))?.send(
+              'session:tokens',
+              {}
+            )
+          })
+        }
+        // Simulate expired session
+        const error4 = document.getElementById('error-4') as HTMLButtonElement
+        if (error4) {
+          error4.addEventListener('click', () => {
+            getEmbedFrame(getDashboardFrameId(runtimeConfig))?.send(
+              'session:tokens',
+              { ...getApplicationTokens(), session_reference_token_ttl: 0 }
+            )
           })
         }
       } else {

--- a/demo/message_utils.ts
+++ b/demo/message_utils.ts
@@ -72,6 +72,7 @@ interface ApplicationTokens {
   api_token_ttl: number
   navigation_token: string
   navigation_token_ttl: number
+  session_reference_token_ttl: number
 }
 
 // TODO consider creating two environment types, one for SSO, one for
@@ -118,12 +119,14 @@ class EmbedEnvironmentTypeImpl {
         api_token_ttl,
         navigation_token,
         navigation_token_ttl,
+        session_reference_token_ttl,
       } = this.sessionData || {}
       return {
         api_token: api_token!,
         api_token_ttl: api_token_ttl!,
         navigation_token: navigation_token!,
         navigation_token_ttl: navigation_token_ttl!,
+        session_reference_token_ttl: session_reference_token_ttl!,
       }
     }
     return undefined
@@ -465,7 +468,7 @@ class EmbedFrameImpl implements EmbedFrame {
   /**
    * Handler for token requests (cookieless embed only)
    */
-  private sessionTokensRequestHandler(_data: any) {
+  private async sessionTokensRequestHandler(_data: any) {
     const contentWindow = this.getContentWindow()
     if (contentWindow) {
       if (!this.connected) {
@@ -485,7 +488,7 @@ class EmbedFrameImpl implements EmbedFrame {
       } else {
         // If connected, the embedded Looker application has decided that
         // it needs new tokens. Generate new tokens.
-        const sessionTokens = this.embedEnvironment.generateTokens()
+        const sessionTokens = await this.embedEnvironment.generateTokens()
         this.send('session:tokens', sessionTokens)
       }
     }
@@ -595,3 +598,13 @@ export const addEmbedFrame = (
  */
 export const getEmbedFrame = (ifameId: string): EmbedFrame =>
   embedFrames.get(ifameId) as EmbedFrame
+
+/**
+ * Returns the application tokens
+ */
+export const getApplicationTokens = () => {
+  if (embedEnvironment.isInitialized && embedEnvironment.isCookielessEmbed) {
+    return { ...embedEnvironment.applicationTokens }
+  }
+  return undefined
+}

--- a/src/embed.ts
+++ b/src/embed.ts
@@ -46,6 +46,7 @@ export class EmbedClient<T> {
   _cookielessApiTokenTtl?: number | null
   _cookielessNavigationToken?: string | null
   _cookielessNavigationTokenTtl?: number | null
+  _cookielessSessionReferenceTokenTtl?: number | null
 
   /**
    * @hidden
@@ -94,11 +95,14 @@ export class EmbedClient<T> {
                 api_token_ttl,
                 navigation_token,
                 navigation_token_ttl,
+                session_reference_token_ttl,
               } = await this._builder.generateTokensCallback()
               this._cookielessApiToken = api_token
               this._cookielessApiTokenTtl = api_token_ttl
               this._cookielessNavigationToken = navigation_token
               this._cookielessNavigationTokenTtl = navigation_token_ttl
+              this._cookielessSessionReferenceTokenTtl =
+                session_reference_token_ttl
             } else {
               this._cookielessInitialized = true
             }
@@ -108,6 +112,8 @@ export class EmbedClient<T> {
               api_token_ttl: this._cookielessApiTokenTtl,
               navigation_token: this._cookielessNavigationToken,
               navigation_token_ttl: this._cookielessNavigationTokenTtl,
+              session_reference_token_ttl:
+                this._cookielessSessionReferenceTokenTtl,
             })
           }
         },
@@ -214,6 +220,7 @@ export class EmbedClient<T> {
       api_token_ttl,
       navigation_token,
       navigation_token_ttl,
+      session_reference_token_ttl,
     } = await acquireSessionCallback()
     if (!authentication_token || !navigation_token || !api_token) {
       throw new Error('failed to prepare cookieless embed session')
@@ -222,6 +229,7 @@ export class EmbedClient<T> {
     this._cookielessApiTokenTtl = api_token_ttl
     this._cookielessNavigationToken = navigation_token
     this._cookielessNavigationTokenTtl = navigation_token_ttl
+    this._cookielessSessionReferenceTokenTtl = session_reference_token_ttl
     const apiHost = `https://${this._builder.apiHost}`
     const sep =
       new URL(this._builder.embedUrl, apiHost).search === '' ? '?' : '&'

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,7 +69,7 @@ export interface LookerEmbedCookielessSessionData {
   /**
    * Session time to live in seconds.
    */
-  session_ttl?: number | null
+  session_reference_token_ttl?: number | null
 }
 
 /**


### PR DESCRIPTION
1. Demo handling of invalid session tokens
2. Demo handling of expired session.
3. Fix types to use session_reference_token_ttl
4. Fix async/await issue with token generation in postMessage demo.