### PR TITLE
fix: show dashboard/look config

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -237,7 +237,7 @@ const initializeShowDashboardCheckbox = () => {
         renderDashboard(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }
@@ -258,7 +258,7 @@ const initializeShowLookCheckbox = () => {
         renderLook(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }
@@ -279,7 +279,7 @@ const initializeShowExploreCheckbox = () => {
         renderExplore(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }
@@ -300,7 +300,7 @@ const initializeShowExtensionCheckbox = () => {
         renderExtension(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }

--- a/demo/demo_config.ts
+++ b/demo/demo_config.ts
@@ -96,10 +96,10 @@ let runtimeConfig: RuntimeConfig = {
   lookId,
   lookerHost,
   preventNavigation: true,
-  showDashboard: !!dashboardId,
+  showDashboard: dashboardId > 0,
   showExplore: !!exploreId,
   showExtension: !!extensionId,
-  showLook: !!lookId,
+  showLook: lookId > 0,
   useCookieless: cookielessEmbedV2,
   useDynamicHeights: false,
 }
@@ -124,7 +124,12 @@ export const loadConfiguration = () => {
   try {
     const configJson = localStorage.getItem('embed-configuration')
     if (configJson) {
-      updateConfiguration(JSON.parse(configJson))
+      const config = JSON.parse(configJson)
+      if (config.lookerHost === runtimeConfig.lookerHost) {
+        updateConfiguration(config)
+      } else {
+        updateConfiguration(runtimeConfig)
+      }
     }
   } catch (error) {
     console.error('error loading embed-configuration', error)

--- a/demo/message_example.ts
+++ b/demo/message_example.ts
@@ -143,7 +143,7 @@ const initializeShowDashboardCheckbox = () => {
         renderDashboard(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }
@@ -164,7 +164,7 @@ const initializeShowLookCheckbox = () => {
         renderLook(runtimeConfig)
       })
     } else {
-      cb.style.display = 'none'
+      cb.parentElement!.style.display = 'none'
     }
   }
 }


### PR DESCRIPTION
When not configured, label was being shown
Changed check for not configure to id > 0
Fixed issue to ignore local storage when looker host changes