### PR TITLE
fix: session not found after dev server recycle

### DIFF
--- a/server_utils/cookieless_utils.ts
+++ b/server_utils/cookieless_utils.ts
@@ -169,9 +169,10 @@ export async function generateEmbedTokens(
     console.error(
       'embed session generate tokens failed, session not yet acquired'
     )
-    throw new Error(
-      'embed session generate tokens failed, session not yet acquired'
-    )
+    // In this scenario return expired session
+    return {
+      session_reference_token_ttl: 0,
+    }
   }
   await acquireLookerSession()
   try {


### PR DESCRIPTION
Sessions are cached in memory in the dev server. If the dev server is recycled the session data is lost. If a generate token request is received and the session is not found, it now returns a session time to live of 0. This causes the UI to display the session expired dialog which is the best result for this scenario,