### PR TITLE
chore: Fixed auto doc generation workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,6 @@ jobs:
         ref: master
     - run: |
         git checkout HEAD
-        rm -rf .git/hooks
 
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
@@ -24,7 +23,10 @@ jobs:
         node-version: ${{ env.NODE_VERSION }}
 
     - name: Install dependencies
-      run: npm ci
+      run: |
+        # Do not install pre-commit package to disable pre-commit hooks
+        sed -i '/"pre-commit": "/d' package.json
+        npm ci
 
     - name: Generate docs
       run: npm run docs

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -11,7 +11,9 @@ jobs:
   docgen:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v3
+      with:
+        ref: master
 
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
@@ -31,10 +33,8 @@ jobs:
     - name: Commit and push changes
       if: steps.git-check.outputs.modified == 'true'
       run: |
+        git checkout HEAD
         git config --global user.name 'Automated Embed SDK Docs Publisher'
         git config --global user.email 'actions@users.noreply.github.com'
-        git commit --no-verify -am "Auto update Embed SDK documentation \n\n Github workflow @ .github/workflow/docs.yml"
-
-        git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}"
-
+        git commit --no-verify -am "Auto generated Embed SDK documentation - Github workflow @ .github/workflow/docs.yml"
         git push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: jeremytchang/docgen
+        ref: master
     - run: git checkout HEAD
 
     - name: Use Node.js ${{ env.NODE_VERSION }}
@@ -36,8 +36,8 @@ jobs:
         fi
       id: git-diff-check
 
-    - name: Commit and push changes
-      if: steps.git-diff-check.outputs.result == 'MODIFIED'
+    - if: steps.git-diff-check.outputs.result == 'MODIFIED'
+      name: Commit and push changes
       run: |
         git config --global user.name 'SDK Docs Bot'
         git config --global user.email 'actions@users.noreply.github.com'

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,7 +13,8 @@ jobs:
     steps:
     - uses: actions/checkout@v3
       with:
-        ref: master
+        ref: jeremytchang/docgen
+    - run: git checkout HEAD
 
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
@@ -26,15 +27,20 @@ jobs:
     - name: Generate docs
       run: npm run docs
 
-    - name: Check for modified files
-      id: git-check
-      run: echo ::set-output name=modified::$(if git diff-index --quiet HEAD --; then echo "false"; else echo "true"; fi)
+    - name: Check for modified doc files
+      run: |
+        if [[ $(git diff --stat docs || true) ]]; then
+          echo "::set-output name=result::MODIFIED"
+        else
+          echo "::set-output name=result::UNMODIFIED"
+        fi
+      id: git-diff-check
 
     - name: Commit and push changes
-      if: steps.git-check.outputs.modified == 'true'
+      if: steps.git-diff-check.outputs.result == 'MODIFIED'
       run: |
-        git checkout HEAD
         git config --global user.name 'SDK Docs Bot'
         git config --global user.email 'actions@users.noreply.github.com'
-        git commit --no-verify -am "Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml"
+        git add docs
+        git commit --no-verify -m "Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml"
         git push

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,9 @@ jobs:
     - uses: actions/checkout@v3
       with:
         ref: master
-    - run: git checkout HEAD
+    - run: |
+        git checkout HEAD
+        rm -rf .git/hooks
 
     - name: Use Node.js ${{ env.NODE_VERSION }}
       uses: actions/setup-node@v1
@@ -36,11 +38,28 @@ jobs:
         fi
       id: git-diff-check
 
+    # - if: steps.git-diff-check.outputs.result == 'MODIFIED'
+    #   name: Commit and push changes
+    #   run: |
+    #     git branch -b autogendoc
+    #     git config --global user.name 'SDK Docs Bot'
+    #     git config --global user.email 'actions@users.noreply.github.com'
+    #     git add docs
+    #     git commit --no-verify -m "Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml"
+    #     git push -f -u origin
+
     - if: steps.git-diff-check.outputs.result == 'MODIFIED'
-      name: Commit and push changes
-      run: |
-        git config --global user.name 'SDK Docs Bot'
-        git config --global user.email 'actions@users.noreply.github.com'
-        git add docs
-        git commit --no-verify -m "Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml"
-        git push
+      name: Create Pull Request
+      uses: peter-evans/create-pull-request@v4
+      with:
+        add-paths: docs/*
+        commit-message: Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml
+        committer: GitHub <noreply@github.com>
+        author: SDK Docs Bot <actions@users.noreply.github.com>
+        branch: autodocgen
+        delete-branch: true
+        title: 'Auto generated Embed SDK docs'
+        body: |
+          PLEASE CLOSE AND REOPEN PR TO TRIGGER CHECKS
+
+          Github workflow @ .github/workflow/docs.yml

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -34,7 +34,7 @@ jobs:
       if: steps.git-check.outputs.modified == 'true'
       run: |
         git checkout HEAD
-        git config --global user.name 'Automated Embed SDK Docs Publisher'
+        git config --global user.name 'SDK Docs Bot'
         git config --global user.email 'actions@users.noreply.github.com'
-        git commit --no-verify -am "Auto generated Embed SDK documentation - Github workflow @ .github/workflow/docs.yml"
+        git commit --no-verify -am "Auto generated Embed SDK docs - Github workflow @ .github/workflow/docs.yml"
         git push

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "build": "npm run clean && npm run build_utils && tsc && webpack",
     "build_utils": "tsc --build tsconfig-server.json",
     "clean": "rm -rf lib dist",
-    "docs": "typedoc --githubPages false --out docs src/index.ts",
+    "docs": "typedoc --gitRevision master --githubPages false --out docs src/index.ts",
     "lint": "eslint --format stylish '**/*.ts'",
     "lint-fix": "eslint --format stylish --fix '**/*.ts'",
     "start": "npm run build_utils && webpack serve --config webpack-devserver.config.js --hot --inline --color --progress",


### PR DESCRIPTION
The doc gen workflow was erroring on being on a detached head.
```
fatal: You are not currently on a branch.
To push the history leading to the current (detached HEAD)
```
My bad. I didn't test git push functionality locally when i first made the workflow. Now tested fully locally.

- Updated to checkout master branch HEAD commit and to make use of the newest actions/checkout so i could follow their latest example code. 
- Update branching logic to be more readable
- Updated diffing and committing logic to specifically only target the docs folder