### PR TITLE
feat: add support for session status events

### DIFF
--- a/demo/demo.ts
+++ b/demo/demo.ts
@@ -31,6 +31,7 @@ import type {
   LookerEmbedDashboard,
   LookerEmbedExplore,
   PagePropertiesChangedEvent,
+  SessionStatus,
 } from '../src/index'
 import { LookerEmbedSDK } from '../src/index'
 import type { RuntimeConfig } from './demo_config'
@@ -342,6 +343,19 @@ const initializeConfigurationControls = () => {
 }
 
 /**
+ * Monitor cookieless embed session status. A simple implementation
+ * that displays a message.
+ */
+const processSessionStatus = (event: SessionStatus, selector: string) => {
+  const { expired, interrupted } = event
+  if (expired) {
+    updateStatus(selector, 'Session has expired')
+  } else if (interrupted) {
+    updateStatus(selector, 'Session has been interrupeted')
+  }
+}
+
+/**
  * Render a dashboard using the Embed SDK. When active this sets up listeners
  * for events that can be sent by the Looker embedded UI.
  */
@@ -375,6 +389,9 @@ const renderDashboard = (runtimeConfig: RuntimeConfig) => {
       )
       .on('page:properties:changed', (event: PagePropertiesChangedEvent) => {
         pagePropertiesChangedHandler(event, 'dashboard')
+      })
+      .on('session:status', (event: SessionStatus) => {
+        processSessionStatus(event, '#dashboard-state')
       })
       // Listen to messages to prevent the user from navigating away
       .on('drillmenu:click', preventNavigation)
@@ -421,6 +438,9 @@ const renderLook = (runtimeConfig: RuntimeConfig) => {
       // Listen to messages that change Look
       .on('look:save:complete', () => updateStatus('#look-state', 'Saved'))
       .on('look:delete:complete', () => updateStatus('#look-state', 'Deleted'))
+      .on('session:status', (event: SessionStatus) => {
+        processSessionStatus(event, '#look-state')
+      })
       // Give the embedded content a class for styling purposes
       .withClassName('looker-embed')
       // Set the initial filters
@@ -457,6 +477,9 @@ const renderExplore = (runtimeConfig: RuntimeConfig) => {
       .on('explore:ready', () => updateStatus('#explore-state', 'Loaded'))
       .on('explore:run:start', () => updateStatus('#explore-state', 'Running'))
       .on('explore:run:complete', () => updateStatus('#explore-state', 'Done'))
+      .on('session:status', (event: SessionStatus) => {
+        processSessionStatus(event, '#explore-state')
+      })
       // Give the embedded content a class for styling purposes
       .withClassName('looker-embed')
       // Set the initial filters
@@ -491,6 +514,9 @@ const renderExtension = (runtimeConfig: RuntimeConfig) => {
     LookerEmbedSDK.createExtensionWithId(runtimeConfig.extensionId)
       // Append to the #extension element
       .appendTo('#extension')
+      .on('session:status', (event: SessionStatus) => {
+        processSessionStatus(event, '#extension-state')
+      })
       // Give the embedded content a class for styling purposes
       .withClassName('looker-embed')
       // Finalize the build

--- a/demo/index.html
+++ b/demo/index.html
@@ -84,7 +84,9 @@
         <div id="explore"></div>
       </div>
       <div id="demo-extension">
-        <div class="embed-header"></div>
+        <div class="embed-header">
+          <div id="extension-state" class="loading-message"></div>
+        </div>
         <div id="extension"></div>
       </div>
     </div>

--- a/demo/message_example.ts
+++ b/demo/message_example.ts
@@ -280,7 +280,7 @@ const initializeDashboardControls = (runtimeConfig: RuntimeConfig) => {
     )
   }
 
-  // Add a listener to the dashboard's "Send session token" button and send a 'session:token' message when clicked
+  // Add a listener to the dashboard's "Send session token" button and send a 'session:tokens' message when clicked
   const stopButton = document.querySelector('#stop-dashboard')
   if (stopButton) {
     stopButton.addEventListener('click', () =>

--- a/src/index.ts
+++ b/src/index.ts
@@ -72,6 +72,8 @@ export class LookerEmbedSDK {
    * a RequestInfo object for a fetch call to the server endpoint that will generate new tokens OR
    * a callback that will invoke the server endpoint that will generate new tokens.
    * The server endpoint should ultimately call the Looker endpoint `generate_tokens_for_cookieless_session`.
+   *
+   * Looker 22.20
    */
   static initCookieless(
     apiHost: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,7 @@ export interface LookerAuthConfig {
 
 /**
  * Cookieless request init
+ * Looker 22.20
  */
 export interface CookielessRequestInit extends RequestInit {
   url: string
@@ -47,12 +48,14 @@ export interface CookielessRequestInit extends RequestInit {
 
 /**
  * Cookieless request callback function
+ * Looker 22.20
  */
 
 export type CookielessCallback = () => Promise<LookerEmbedCookielessSessionData>
 
 /**
  * Cookieless session data
+ * Looker 23.0
  */
 export interface LookerEmbedCookielessSessionData {
   /**
@@ -178,6 +181,42 @@ export interface LookerEmbedEvent {
 
 export interface EventDetail {
   [key: string]: any
+}
+
+/**
+ * Cookieless embed session token request
+ *  * Looker 22.20
+ */
+
+export type SessionTokenRequest = EventDetail
+
+/**
+ * Cookieless session status event
+ *  * Looker 23.0
+ */
+
+export interface SessionStatus extends EventDetail {
+  /**
+   * Session time to live in seconds
+   */
+  session_ttl: number
+  /**
+   * Session expired when true
+   */
+  expired: boolean
+  /**
+   * Session interrupted when true. This means new
+   * tokens could not be retrieved in a timely manner.
+   * Can happen if server is temporarily unavailable
+   * for some reason
+   */
+  interrupted: boolean
+  /**
+   * Interrupted session can be recovered. When false
+   * session cannot continue. This is most likely
+   * a problem with the embedding application.
+   */
+  recoverable?: boolean
 }
 
 /**
@@ -524,6 +563,19 @@ export interface LookerEmbedEventMap {
     this: LookerEmbedBase,
     event: PagePropertiesChangedEvent
   ) => void
+  /**
+   * Cookieless embed session tokens request event
+   * Looker 22.20
+   */
+  'session:token:request': (
+    this: LookerEmbedBase,
+    event: SessionTokenRequest
+  ) => void
+  /**
+   * Cookieless embed session status event
+   * Looker 23.0
+   */
+  'session:status': (this: LookerEmbedBase, event: SessionStatus) => void
 
   [key: string]: any
 }


### PR DESCRIPTION
Requires Looker 23.0. Publishing early to make adopters aware.