### PR TITLE
feat: demo and document cookieless session embed domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,17 @@ LookerEmbedSDK.initCookieless(
 )
 ```
 
+### Embed domain allow list
+
+Looker embed SSO requires that the host application domain be added to an allow list using the Looker configure admin page. Starting with Looker version `23.8`, the embed domain can be specified in the payload of the `acquire_embed_cookieless_session` call. This allows customers to dynamically specify the allowed domains. Note that the allowed domain is associated with the embed session stored in the Looker server. It is NOT persisted to the internal Looker database. This means that the embed domain must be included with every `acquire_embed_cookieless_session` call. 
+
+When implementing it is HIGHLY recommended that that the implementor
+NOT trust any embed domain sent from the browser (in other words do
+use the location.origin from the browser). Instead, the embed application should implement a mechanism in the server that maps a
+user to particular domain. 
+
+To add the embed domain to the `acquire_embed_cookieless_session` payload set the `LOOKER_USE_EMBED_DOMAIN` variable to true in the `.env` file
+
 ## Demo
 
 A simple demo is provided in the `/demo` directory that uses a basic JS frontend and a Python backend. The example backend `demo.py` uses the Looker API to create a signed URL. The example backend `demo_self_signed.py` uses the embed secret and a helper function to sign the URL. The instructions below are for the example using the Looker API.
@@ -585,7 +596,9 @@ LOOKER_DASHBOARD_ID=1
 LOOKER_LOOK_ID=1
 LOOKER_EXPLORE_ID=thelook::orders
 LOOKER_EXTENSION_ID=extension::my-great-extension
+LOOKER_USE_EMBED_DOMAIN=false
 COOKIE_SECRET=cookie_stash
+LOOKER_USE_EMBED_DOMAIN=false
 ```
 
 ## Embedded Javascript Events

--- a/config.js
+++ b/config.js
@@ -10,6 +10,7 @@ module.exports = {
   client_id: process.env.LOOKER_CLIENT_ID,
   client_secret: process.env.LOOKER_CLIENT_SECRET,
   verify_ssl: process.env.LOOKER_VERIFY_SSL === 'true' || false,
+  use_embed_domain: process.env.LOOKER_USE_EMBED_DOMAIN === 'true' || false,
   cookie_secret: (process.env.COOKIE_SECRET || 'secret').padEnd(
     32,
     'ABCDEFGHIJKLMNOPQRSTUVWZYZ0123456'

--- a/docs/index.html
+++ b/docs/index.html
@@ -161,6 +161,16 @@ the <code>session_reference_token_ttl</code> value will be set to 0. When this h
 <pre><code class="language-javascript"><span class="hl-0">LookerEmbedSDK</span><span class="hl-1">.</span><span class="hl-2">initCookieless</span><span class="hl-1">(</span><br/><span class="hl-1">  </span><span class="hl-3">&#39;looker.example.com&#39;</span><span class="hl-1">,</span><br/><span class="hl-1">  </span><span class="hl-3">&#39;/acquire-embed-session&#39;</span><span class="hl-1">,</span><br/><span class="hl-1">  </span><span class="hl-3">&#39;/generate-embed-tokens&#39;</span><br/><span class="hl-1">)</span>
 </code></pre>
 
+<a href="#embed-domain-allow-list" id="embed-domain-allow-list" style="color: inherit; text-decoration: none;">
+  <h3>Embed domain allow list</h3>
+</a>
+<p>Looker embed SSO requires that the host application domain be added to an allow list using the Looker configure admin page. Starting with Looker version <code>23.8</code>, the embed domain can be specified in the payload of the <code>acquire_embed_cookieless_session</code> call. This allows customers to dynamically specify the allowed domains. Note that the allowed domain is associated with the embed session stored in the Looker server. It is NOT persisted to the internal Looker database. This means that the embed domain must be included with every <code>acquire_embed_cookieless_session</code> call. </p>
+<p>When implementing it is HIGHLY recommended that that the implementor
+NOT trust any embed domain sent from the browser (in other words do
+use the location.origin from the browser). Instead, the embed application should implement a mechanism in the server that maps a
+user to particular domain. </p>
+<p>To add the embed domain to the <code>acquire_embed_cookieless_session</code> payload set the <code>LOOKER_USE_EMBED_DOMAIN</code> variable to true in the <code>.env</code> file</p>
+
 <a href="#demo" id="demo" style="color: inherit; text-decoration: none;">
   <h2>Demo</h2>
 </a>
@@ -254,7 +264,7 @@ in a browser console with</p>
   <h3><a name='env' id='env'></a> <code>.env</code> setup</h3>
 </a>
 <p>The embed demo environment can be configured using a <code>.env</code> file. The following is a template that can be used to create the file (in the root of this repo). The <code>.env</code> file should never be stored in your git repo and is included in the repo&#39;s <code>.ignore</code> file.</p>
-<pre><code class="language-shell"><span class="hl-1">LOOKER_EMBED_HOST=mycompany.looker.com</span><br/><span class="hl-1">LOOKER_EMBED_API_URL=https://mycompany.looker.com:19999</span><br/><span class="hl-1">LOOKER_DEMO_HOST=localhost</span><br/><span class="hl-1">LOOKER_DEMO_PORT=8080</span><br/><span class="hl-1">LOOKER_EMBED_SECRET=</span><br/><span class="hl-1">LOOKER_CLIENT_ID=</span><br/><span class="hl-1">LOOKER_CLIENT_SECRET=</span><br/><span class="hl-1">LOOKER_DASHBOARD_ID=1</span><br/><span class="hl-1">LOOKER_LOOK_ID=1</span><br/><span class="hl-1">LOOKER_EXPLORE_ID=thelook::orders</span><br/><span class="hl-1">LOOKER_EXTENSION_ID=extension::my-great-extension</span><br/><span class="hl-1">COOKIE_SECRET=cookie_stash</span>
+<pre><code class="language-shell"><span class="hl-1">LOOKER_EMBED_HOST=mycompany.looker.com</span><br/><span class="hl-1">LOOKER_EMBED_API_URL=https://mycompany.looker.com:19999</span><br/><span class="hl-1">LOOKER_DEMO_HOST=localhost</span><br/><span class="hl-1">LOOKER_DEMO_PORT=8080</span><br/><span class="hl-1">LOOKER_EMBED_SECRET=</span><br/><span class="hl-1">LOOKER_CLIENT_ID=</span><br/><span class="hl-1">LOOKER_CLIENT_SECRET=</span><br/><span class="hl-1">LOOKER_DASHBOARD_ID=1</span><br/><span class="hl-1">LOOKER_LOOK_ID=1</span><br/><span class="hl-1">LOOKER_EXPLORE_ID=thelook::orders</span><br/><span class="hl-1">LOOKER_EXTENSION_ID=extension::my-great-extension</span><br/><span class="hl-1">LOOKER_USE_EMBED_DOMAIN=false</span><br/><span class="hl-1">COOKIE_SECRET=cookie_stash</span><br/><span class="hl-1">LOOKER_USE_EMBED_DOMAIN=false</span>
 </code></pre>
 
 <a href="#embedded-javascript-events" id="embedded-javascript-events" style="color: inherit; text-decoration: none;">

--- a/server/config.ts
+++ b/server/config.ts
@@ -42,5 +42,6 @@ export const config: ApplicationConfig = {
   demo_port: parseInt(process.env.LOOKER_DEMO_PORT || '8080', 10),
   host: process.env.LOOKER_EMBED_HOST || 'self-signed.looker.com:9999',
   secret: process.env.LOOKER_EMBED_SECRET!,
+  use_embed_domain: process.env.LOOKER_USE_EMBED_DOMAIN === 'true' || false,
   verify_ssl: process.env.LOOKER_VERIFY_SSL === 'true' || false,
 }

--- a/server/types.ts
+++ b/server/types.ts
@@ -68,4 +68,5 @@ export interface ApplicationConfig {
   secret: string
   verify_ssl: boolean
   cookie_secret: string
+  use_embed_domain: boolean
 }

--- a/server/utils/cookieless_utils.ts
+++ b/server/utils/cookieless_utils.ts
@@ -94,9 +94,13 @@ const acquireEmbedSessionInternal = async (
   session_reference_token?: string
 ) => {
   try {
-    const request = {
+    // TODO type when 23.8 Looker SDK is published
+    const request: any = {
       ...user,
       session_reference_token: session_reference_token,
+    }
+    if (config.use_embed_domain) {
+      request.embed_domain = `http://${config.demo_host}:${config.demo_port}`
     }
     const sdk = new Looker40SDK(lookerSession)
     const response = await sdk.ok(

--- a/webpack-devserver.config.js
+++ b/webpack-devserver.config.js
@@ -43,6 +43,7 @@ var webpackConfig = {
       LOOKER_EXPLORE_ID: null,
       LOOKER_EXTENSION_ID: null,
       LOOKER_COOKIELESS_ENABLED: null,
+      LOOKER_USE_EMBED_DOMAIN: null,
     }),
   ],
   devServer: {


### PR DESCRIPTION
embed domains can now be associated the cookieless embed session as an alternative to definiing in the Looker embed configuration admin page. This changed demonstrates and documents this feature.