### PR TITLE
feat: support signed embed urls during backend session creation

### DIFF
--- a/src/embed.ts
+++ b/src/embed.ts
@@ -290,6 +290,7 @@ export class EmbedClient<T> {
       navigation_token,
       navigation_token_ttl,
       session_reference_token_ttl,
+      signed_embed_url,
     } = await this.acquireSession()
     if (!authentication_token || !navigation_token || !api_token) {
       throw new Error('failed to prepare cookieless embed session')
@@ -299,6 +300,9 @@ export class EmbedClient<T> {
     this._cookielessNavigationToken = navigation_token
     this._cookielessNavigationTokenTtl = navigation_token_ttl
     this._cookielessSessionReferenceTokenTtl = session_reference_token_ttl
+    if (signed_embed_url) {
+      return signed_embed_url
+    }
     const apiHost = `https://${this._builder.apiHost}`
     const sep =
       new URL(this._builder.embedUrl, apiHost).search === '' ? '?' : '&'

--- a/src/types.ts
+++ b/src/types.ts
@@ -86,6 +86,13 @@ export interface LookerEmbedCookielessSessionData {
    * Session time to live in seconds.
    */
   session_reference_token_ttl?: number | null
+
+  /**
+   * Backend generated embed url for sessions with access to an exclusive component.
+   * For when using callback methods that inject additional information for session creation.
+   * If present, this value bypasses local url generation.
+   */
+  signed_embed_url?: string | null
 }
 
 /**


### PR DESCRIPTION
This would unblock our team's use case, where we want to exclusively initiate a session for a particular LookML component (e.g. dashboard) and because there's sensitive information we don't want to pass to the frontend to generate the url , we need to generate the embed signed url in the backend and pass it back to the frontend running Embed SDK.

Let me know if this is PR is enough or if we need any additional work done; this is quite important for us.

We're in contact with the Looker Engineering team, so they can also provide information over our several use cases that are out of norm and may require additional context.