### PR TITLE
fix: unexpected console error from pendo messsages in demo

### DIFF
--- a/demo/message_utils.ts
+++ b/demo/message_utils.ts
@@ -406,7 +406,7 @@ class EmbedFrameImpl implements EmbedFrame {
         if (data) {
           let parsedData: any
           try {
-            parsedData = JSON.parse(data)
+            parsedData = typeof data === 'object' ? data : JSON.parse(data)
           } catch (error) {
             console.error('data is not json', { data })
           }


### PR DESCRIPTION
The embed javascript demo was rendering an unexpected error message in the javascript console. The type of message data is now checked prior to parsing it.