### PR TITLE
feat: allow duplicate values for URL params

### DIFF
--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -44,13 +44,19 @@ interface LookerEmbedHostSettings {
 }
 
 export interface UrlParams {
-  [key: string]: string
+  [key: string]: string | string[]
 }
 
-function stringify(params: { [key: string]: string }) {
+function stringify(params: UrlParams) {
   const result = []
   for (const key in params) {
-    result.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    const value = params[key]
+    const valueArray = Array.isArray(value) ? value : [value]
+    for (const singleValue of valueArray) {
+      result.push(
+        `${encodeURIComponent(key)}=${encodeURIComponent(singleValue)}`
+      )
+    }
   }
   return result.join('&')
 }

--- a/tests/embed_builder.spec.ts
+++ b/tests/embed_builder.spec.ts
@@ -250,6 +250,11 @@ describe('LookerEmbedBuilder', () => {
       expect(builder.embedUrl).toMatch('alpha=1&beta=2')
     })
 
+    it('should allow multiple values for an url parameter', () => {
+      builder.withParams({ hide_filter: ['1', '2'] })
+      expect(builder.embedUrl).toMatch('hide_filter=1&hide_filter=2')
+    })
+
     it('should allow specifying a theme', () => {
       builder.withTheme('Fancy')
       expect(builder.embedUrl).toMatch('theme=Fancy')


### PR DESCRIPTION
Allow duplicate same-named params, so as to support multiple hide_filter.

Fixes #151 , Fixes #159 