### PR TITLE
feat: extend withParams so it works also with list

### DIFF
--- a/src/embed_builder.ts
+++ b/src/embed_builder.ts
@@ -44,14 +44,26 @@ interface LookerEmbedHostSettings {
 }
 
 export interface UrlParams {
-  [key: string]: string
+  [key: string]: string | string[]
 }
 
-function stringify(params: { [key: string]: string }) {
+function formatParameter(key: string, value: string) {
+  return `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
+}
+
+function stringify(params: { [key: string]: string | string[] }) {
   const result = []
   for (const key in params) {
-    result.push(`${encodeURIComponent(key)}=${encodeURIComponent(params[key])}`)
+    const value = params[key]
+    if (Array.isArray(value)) {
+      value.forEach((v: string) => {
+        result.push(formatParameter(key, v))
+      })
+    } else {
+      result.push(formatParameter(key, value))
+    }
   }
+
   return result.join('&')
 }
 

--- a/tests/embed_builder.spec.ts
+++ b/tests/embed_builder.spec.ts
@@ -250,6 +250,11 @@ describe('LookerEmbedBuilder', () => {
       expect(builder.embedUrl).toMatch('alpha=1&beta=2')
     })
 
+    it('should add url parameters / list', () => {
+      builder.withParams({ values: ['1', '2'] })
+      expect(builder.embedUrl).toMatch('values=1&values=2')
+    })
+
     it('should allow specifying a theme', () => {
       builder.withTheme('Fancy')
       expect(builder.embedUrl).toMatch('theme=Fancy')


### PR DESCRIPTION
With this PR we allow withParams to accept `Record<string, string | string[]>`, instead of just `Record<string, string>`.

```
.withParams({ key: ["foo", "bar"] })
```

It also updates the private `stringify` function to handle this case nicely, eg. `&key=foo&key=bar`.

This functionality is useful so that also SDK's user are allowed to hide dashboard filters ([doc](https://cloud.google.com/looker/docs/filters-user-defined-dashboards#hiding_dashboard_filters)).