### PR TITLE
fix: Ensure generateTokensPromise cleared on failure

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@looker/embed-sdk",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@looker/embed-sdk",
-      "version": "2.0.9",
+      "version": "2.0.10",
       "license": "MIT",
       "dependencies": {
         "@looker/chatty": "^2.3.10",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@looker/embed-sdk",
-  "version": "2.0.9",
+  "version": "2.0.10",
   "description": "A toolkit for embedding Looker",
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",

--- a/src/EmbedClientEx.ts
+++ b/src/EmbedClientEx.ts
@@ -400,6 +400,10 @@ export class EmbedClientEx implements IEmbedClient {
                 // cookielessSessionReferenceTokenTtl of null means we did not
                 // get valid tokens
                 cookielessSession.cookielessSessionReferenceTokenTtl = null
+              } finally {
+                // Clear the generateTokensPromise. All IFRAMEs will queue up
+                // on the same promise
+                this._sdk._generateTokensPromise = undefined
               }
             }
           } else {
@@ -477,10 +481,6 @@ export class EmbedClientEx implements IEmbedClient {
           session_reference_token_ttl:
             cookielessSession.cookielessSessionReferenceTokenTtl,
         })
-
-        // Clear the generateTokensPromise. All IFRAMEs will queue up
-        // on the same promise
-        this._sdk._generateTokensPromise = undefined
       })
     }
 


### PR DESCRIPTION
Failure to do so resulted in the resume session button not working.